### PR TITLE
feat: change PlayTools installation behavior

### DIFF
--- a/PlayCover/AppInstaller/Installer.swift
+++ b/PlayCover/AppInstaller/Installer.swift
@@ -37,8 +37,17 @@ class Installer {
 
     // swiftlint:disable function_body_length
     static func install(ipaUrl: URL, export: Bool, returnCompletion: @escaping (URL?) -> Void) {
-        let installPlayTools = (InstallSettings.shared.showInstallPlayToolsPopup && !export) ?
-            installPlayToolsPopup() : InstallSettings.shared.alwaysInstallPlayTools
+        let installPlayTools: Bool
+
+        if InstallSettings.shared.showInstallPlayToolsPopup {
+            installPlayTools = !export ? installPlayToolsPopup() : InstallSettings.shared.alwaysInstallPlayTools
+        } else {
+            if Installer.isOptionKeyHeld {
+                installPlayTools = installPlayToolsPopup()
+            } else {
+                installPlayTools = InstallSettings.shared.alwaysInstallPlayTools
+            }
+        }
 
         InstallVM.shared.next(.begin, 0.0, 0.0)
 
@@ -206,5 +215,11 @@ class Installer {
     /// Regular codesign, does not accept entitlements. Used to re-seal an app after you've modified it.
     static func fakesign(_ url: URL) throws {
         try shell.shello("/usr/bin/codesign", "-fs-", url.path)
+    }
+    
+    static var isOptionKeyHeld: Bool {
+        get {
+            NSEvent.modifierFlags.contains(.option)
+        }
     }
 }

--- a/PlayCover/Views/Settings/InstallSettings.swift
+++ b/PlayCover/Views/Settings/InstallSettings.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct InstallSettings: View {
     public static var shared = InstallSettings()
 
-    @AppStorage("ShowInstallPlayToolsPopup") var showInstallPlayToolsPopup = true
+    @AppStorage("ShowInstallPlayToolsPopup") var showInstallPlayToolsPopup = false
     @AppStorage("AlwaysInstallPlayTools") var alwaysInstallPlayTools = true
 
     var body: some View {


### PR DESCRIPTION
Change the PlayTools install behavior so
- Respect default settings
- Allows an overriding key to be used to override defaults
- Seamless for older users